### PR TITLE
Test: Use waitForElementToBeRemoved in the Interaction test to prevent flakiness

### DIFF
--- a/src/components/InboxScreen.stories.js
+++ b/src/components/InboxScreen.stories.js
@@ -1,7 +1,11 @@
 import React from "react";
 import { Provider } from "react-redux";
 import { rest } from "msw";
-import { fireEvent, within } from "@storybook/testing-library";
+import {
+  fireEvent,
+  within,
+  waitForElementToBeRemoved,
+} from "@storybook/testing-library";
 import InboxScreen from "./InboxScreen";
 import store from "../lib/store";
 
@@ -51,14 +55,19 @@ Default.parameters = {
     },
   },
 };
-// Function to emulate pausing between interactions
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-Default.play = async ({ canvasElement }) => {
-  sleep(3000);
-  const canvas = within(canvasElement);
 
+Default.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await waitForElementToBeRemoved(
+    await canvas.findByText("You have no tasks"),
+    {
+      timeout: 3000,
+    }
+  );
+  /* await waitForElementToBeRemoved(
+    () => canvas.getByText("You have no tasks"),
+    { timeout: 2000 }
+  ); */
   // Simulates pinning the first task
   await fireEvent.click(canvas.getByLabelText("pinTask-1"));
   // Simulates pinning the third task


### PR DESCRIPTION
With this pull request, the InboxScreen interaction test is updated to include waitForElementToBeRemoved instead of waitFor to prevent flakiness and a misleading error message when the story loads since it requires the data to be injected by the MSW addon

